### PR TITLE
Specify library dependencies in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -8,3 +8,4 @@ category=Sensors
 url=https://github.com/NorthernWidget/ALog
 architectures=*
 includes=SdFat.h,Wire.h,DS3231.h,math.h,avr/sleep.h,avr/wdt.h,stdlib.h,SFE_BMP180.h
+depends=SdFat,DS3231


### PR DESCRIPTION
Specifying the library dependencies in the `depends` field of library.properties causes the Arduino Library Manager (Arduino IDE 1.8.10 and newer) to offer to install any missing dependencies during installation of this library.

`arduino-cli lib install` will automatically install the dependencies (arduino-cli 0.7.0 and newer).

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format